### PR TITLE
Add Severity option to CLI and exit with code 1 on Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ package_rule • package:import_analyzer_test/repository/test_one_repository.dar
 4 issues found.
 ```
 
+## Option
+### CLI
+#### Rule Severities
+
+To change the severity of a rule, add a `severity` key to the rule configuration.
+
+- `warning` (default)
+- `error` (exit code 1 when lint is found)
+
+```yaml
+import_lint:
+    severity: 'error'
+    rules: ...
+```
+
 ## Contribution
 
 Welcome PRs!

--- a/bin/import_lint.dart
+++ b/bin/import_lint.dart
@@ -4,9 +4,9 @@ import 'package:import_lint/src/cli.dart' as cli;
 
 void main(List<String> args) async {
   try {
-    await cli.run(args);
+    final exitCode = await cli.run(args);
 
-    io.exit(0);
+    io.exit(exitCode);
   } catch (e, s) {
     io.stdout.writeln('${e.toString()}\n');
     io.stdout.writeln('''

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -41,10 +41,9 @@ Future<HasError> runLinter(DriverBasedAnalysisContext context) async {
 
   final errors = <AnalysisError>[];
 
-  for (final file in files) {
-    final fileErrors = await getErrors(options, context, file.path);
-    errors.addAll(fileErrors);
-  }
+  final tasks = files.map((file) => getErrors(options, context, file.path));
+  final results = await Future.wait(tasks);
+  errors.addAll(results.toList().expand((e) => e));
 
   final bool hasError =
       errors.where((e) => e.severity == AnalysisErrorSeverity.ERROR).isNotEmpty;

--- a/lib/src/rule.dart
+++ b/lib/src/rule.dart
@@ -50,6 +50,7 @@ Future<List<AnalysisError>> getErrors(
   for (final rule in options.rules.value) {
     result.unit.visitChildren(
       _ImportLintVisitor(
+        options.common,
         rule,
         result.path,
         packageName,
@@ -76,6 +77,7 @@ class _ImportSource {
 
 class _ImportLintVisitor extends SimpleAstVisitor<void> {
   _ImportLintVisitor(
+    this.commonOption,
     this.ruleOption,
     this.filePath,
     this.packageName,
@@ -84,6 +86,7 @@ class _ImportLintVisitor extends SimpleAstVisitor<void> {
     this.onError,
   );
 
+  final CommonOption commonOption;
   final RuleOption ruleOption;
   final String filePath;
   final String packageName;
@@ -166,7 +169,7 @@ class _ImportLintVisitor extends SimpleAstVisitor<void> {
         final locEnd = lineInfo.getLocation(node.uri.end);
 
         final error = AnalysisError(
-          AnalysisErrorSeverity('WARNING'),
+          commonOption.severity,
           AnalysisErrorType.LINT,
           Location(
             filePath,

--- a/test/rule.test.dart
+++ b/test/rule.test.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/src/dart/analysis/context_locator.dart';
 import 'package:analyzer/src/dart/analysis/driver_based_analysis_context.dart';
 import 'package:analyzer/src/test_utilities/mock_sdk.dart';
 import 'package:analyzer/src/test_utilities/resource_provider_mixin.dart';
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:glob/glob.dart';
 import 'package:import_lint/src/lint_options.dart';
 import 'package:import_lint/src/rule.dart';
@@ -105,7 +106,10 @@ import '3_not.dart';
           ),
         ],
       ),
-      common: CommonOption(directoryPath: '/'),
+      common: CommonOption(
+        directoryPath: '/',
+        severity: AnalysisErrorSeverity.WARNING,
+      ),
     );
 
     final errors = await getErrors(options, context, testFilePath);
@@ -158,7 +162,10 @@ import '3_test.dart';
           ),
         ],
       ),
-      common: CommonOption(directoryPath: '/'),
+      common: CommonOption(
+        directoryPath: '/',
+        severity: AnalysisErrorSeverity.WARNING,
+      ),
     );
 
     final errors = await getErrors(options, context, testFilePath);
@@ -256,7 +263,10 @@ import 'package:$_anotherPackageName/test/1_test.dart';
           ),
         ],
       ),
-      common: CommonOption(directoryPath: '/'),
+      common: CommonOption(
+        directoryPath: '/',
+        severity: AnalysisErrorSeverity.WARNING,
+      ),
     );
 
     final errors = await getErrors(options, context, testFilePath);
@@ -307,7 +317,10 @@ import 'package:$_anotherPackageName/test/1_test.dart';
           ),
         ],
       ),
-      common: CommonOption(directoryPath: '/'),
+      common: CommonOption(
+        directoryPath: '/',
+        severity: AnalysisErrorSeverity.WARNING,
+      ),
     );
 
     final errors = await getErrors(options, context, testFilePath);
@@ -399,7 +412,10 @@ import '3_not.dart';
           ),
         ],
       ),
-      common: CommonOption(directoryPath: '/'),
+      common: CommonOption(
+        directoryPath: '/',
+        severity: AnalysisErrorSeverity.WARNING,
+      ),
     );
 
     final errors = await getErrors(options, context, testFilePath);


### PR DESCRIPTION
## Background
- Since my project did not have access to multiple analysis options, I decided to run the CLI with CI.
	```shell
	warning • Multiple plugins can't be enabled • analysis_options.yaml:5:7 • multiple_plugins
	```

## Changes
- Added Severity as an Option
  - Exit Code 1 is returned in case of Error.
- Improved performance
  - Parallelize the processing of files.
  - This has improved performance by 40%, from 50 ~ 55sec to 30 ~ 35sec in my project. There is still room for parallelization.

## Added Features/Enhancements
- Added Severity as an Option

## Test Results/Method
- Please let me know if you need additional TESTs.

## Points to Review
- Since this was a CLI need, we have not included support for the plugin side. Please tell me know if need.
(In this case, the format of the analyze option may be set to `analyzer.errors.xxx`…?)
- I'm not sure if the severity option is defined in the right place, what do you think?
