### PR TITLE
Fix issue where exclude_imports only applied to directories under not_allow_imports

### DIFF
--- a/lib/src/lint_options.dart
+++ b/lib/src/lint_options.dart
@@ -141,15 +141,15 @@ class RuleOption {
 }
 
 class ImportRulePath {
-  const ImportRulePath(this.package, this.path);
+  const ImportRulePath(this.package, this.glob);
 
   factory ImportRulePath.from(String value, CommonOption commonOption) {
     final package = RegExp('(?<=package:).*?(?=\/)').stringMatch(value);
     if (package != null) {
       final importPath = value.replaceFirst('package:$package/', '');
-      final path = Glob(importPath, recursive: true, caseSensitive: false);
+      final glob = Glob(importPath, recursive: true, caseSensitive: false);
 
-      return ImportRulePath(package, path);
+      return ImportRulePath(package, glob);
     }
 
     final path = Glob(value, recursive: true, caseSensitive: false);
@@ -157,7 +157,7 @@ class ImportRulePath {
   }
 
   final String? package;
-  final Glob path;
+  final Glob glob;
 
   String fixedPackage(String workspacePackage) =>
       package == null ? workspacePackage : package!;

--- a/lib/src/rule.dart
+++ b/lib/src/rule.dart
@@ -144,13 +144,13 @@ class _ImportLintVisitor extends SimpleAstVisitor<void> {
 
     for (final notAllowImportRule in ruleOption.notAllowImports) {
       if (notAllowImportRule.path.matches(importSource.source)) {
-        final isIgnore = ruleOption.excludeImports.map((e) {
-          final matchIgnore = e.path.matches(importSource.source);
+        final bool isIgnore = ruleOption.excludeImports.any((e) {
+          final matchIgnore = e.path.matches(libFilePath);
           final equalPackage =
               importSource.package == e.fixedPackage(packageName);
 
           return matchIgnore && equalPackage;
-        }).contains(true);
+        });
 
         if (isIgnore) {
           continue;

--- a/lib/src/rule.dart
+++ b/lib/src/rule.dart
@@ -143,9 +143,9 @@ class _ImportLintVisitor extends SimpleAstVisitor<void> {
     }
 
     for (final notAllowImportRule in ruleOption.notAllowImports) {
-      if (notAllowImportRule.path.matches(importSource.source)) {
+      if (notAllowImportRule.glob.matches(importSource.source)) {
         final bool isIgnore = ruleOption.excludeImports.any((excludePath) {
-          final matchIgnorePath = excludePath.path.matches(currentTargetPath);
+          final matchIgnorePath = excludePath.glob.matches(currentTargetPath);
           final equalPackage =
               importSource.package == excludePath.fixedPackage(packageName);
 

--- a/lib/src/rule.dart
+++ b/lib/src/rule.dart
@@ -136,20 +136,20 @@ class _ImportLintVisitor extends SimpleAstVisitor<void> {
       return;
     }
 
-    final libFilePath = toPackagePath(filePath);
+    final currentTargetPath = toPackagePath(filePath);
 
-    if (!ruleOption.targetFilePath.matches(libFilePath)) {
+    if (!ruleOption.targetFilePath.matches(currentTargetPath)) {
       return;
     }
 
     for (final notAllowImportRule in ruleOption.notAllowImports) {
       if (notAllowImportRule.path.matches(importSource.source)) {
-        final bool isIgnore = ruleOption.excludeImports.any((e) {
-          final matchIgnore = e.path.matches(libFilePath);
+        final bool isIgnore = ruleOption.excludeImports.any((excludePath) {
+          final matchIgnorePath = excludePath.path.matches(currentTargetPath);
           final equalPackage =
-              importSource.package == e.fixedPackage(packageName);
+              importSource.package == excludePath.fixedPackage(packageName);
 
-          return matchIgnore && equalPackage;
+          return matchIgnorePath && equalPackage;
         });
 
         if (isIgnore) {

--- a/test/lint_options.test.dart
+++ b/test/lint_options.test.dart
@@ -80,11 +80,11 @@ import_lint:
       null,
     );
     expect(
-      testRule.notAllowImports.first.path.pattern,
+      testRule.notAllowImports.first.glob.pattern,
       Glob('test/*.dart', recursive: true, caseSensitive: false).pattern,
     );
     expect(
-      testRule.excludeImports.first.path.pattern,
+      testRule.excludeImports.first.glob.pattern,
       Glob('not_test/*.dart', recursive: true, caseSensitive: false).pattern,
     );
 
@@ -100,7 +100,7 @@ import_lint:
       'import_lint',
     );
     expect(
-      packageRule.notAllowImports.first.path.pattern,
+      packageRule.notAllowImports.first.glob.pattern,
       Glob('import_lint.dart', recursive: true, caseSensitive: false).pattern,
     );
   }

--- a/test/rule.test.dart
+++ b/test/rule.test.dart
@@ -314,6 +314,57 @@ import 'package:$_anotherPackageName/test/1_test.dart';
 
     expect(errors.length, 0);
   }
+
+  void test_excludeImport_diffDirectory() async {
+    final testFilePath = '/lib/$_packageDir/use_case/1_test.dart';
+    final testFileContent = '''
+import 'package:$_anotherPackageName/repository/1_test.dart';
+''';
+
+    resourceProvider.newFile(testFilePath, testFileContent);
+
+    final context = _buildContext();
+
+    final options = LintOptions(
+      rules: RulesOption(
+        [
+          RuleOption(
+            name: 'name',
+            targetFilePath: Glob(
+              '**/*.dart',
+              recursive: true,
+              caseSensitive: false,
+            ),
+            notAllowImports: [
+              ImportRulePath(
+                _anotherPackageName,
+                Glob(
+                  'repository/**.dart',
+                  recursive: true,
+                  caseSensitive: false,
+                ),
+              ),
+            ],
+            excludeImports: [
+              ImportRulePath(
+                _anotherPackageName,
+                Glob(
+                  'use_case/**.dart',
+                  recursive: true,
+                  caseSensitive: false,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      common: CommonOption(directoryPath: '/'),
+    );
+
+    final errors = await getErrors(options, context, testFilePath);
+
+    expect(errors.length, 0);
+  }
 }
 
 @reflectiveTest


### PR DESCRIPTION
fixes https://github.com/kawa1214/import-lint/issues/28

## Background
- `exclude_imports` was only judging directories under `not_allow_imports`.

## Changes
- change target path 
- refactor: rename variables

## Points to Review
- Correctness of corrections
- Refactor Policy
